### PR TITLE
Use the right SSH key when exporting the kube config

### DIFF
--- a/keys.tf
+++ b/keys.tf
@@ -27,7 +27,7 @@ resource "null_resource" "write_kubeconfig" {
   provisioner "local-exec" {
     command = <<EOF
       ssh-keygen -R ${local.external_ip} >/dev/null 2>&1
-      until rsync -e "ssh -o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" --rsync-path="sudo rsync" ${var.servers[0].system_user}@${local.external_ip}:/etc/rancher/rke2/rke2.yaml rke2.yaml >/dev/null 2>&1; do echo Wait rke2.yaml generation && sleep 5; done \
+      until rsync -e "ssh -o ConnectTimeout=5 -i ${replace(var.ssh_public_key_file, ".pub", "")} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" --rsync-path="sudo rsync" ${var.servers[0].system_user}@${local.external_ip}:/etc/rancher/rke2/rke2.yaml rke2.yaml >/dev/null 2>&1; do echo Wait rke2.yaml generation && sleep 5; done \
       && chmod go-r rke2.yaml \
       && yq eval --inplace '.clusters[0].name = "${var.name}-cluster"' rke2.yaml \
       && yq eval --inplace '.clusters[0].cluster.server = "https://${local.external_ip}:6443"' rke2.yaml \


### PR DESCRIPTION
If the key is not seen by SSH (e.g. on CI environment, where the key is simply available as a file), the command will (silently) fail forever as it can't connect to the host.

I'm not too happy with my fix, perhaps it would be better to introduce a variable for users to provide the private key, but then it must be ensured the user provides both (e.g. TF variable validation).