### PR TITLE
feat: HA tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ grep -r -A 1 repository: .
 crictl
 sudo systemctl status rke2-server
 
+# kubelet log
+less /var/lib/rancher/rke2/agent/logs/kubelet.log
+
+# containerd log
+less /var/lib/rancher/rke2/agent/containerd/containerd.log
+
 # restore s3 snapshot
 sudo systemctl stop rke2-server && sudo rke2 server --cluster-reset --etcd-s3 --etcd-s3-bucket=BUCKET_NAME --etcd-s3-access-key=ACCESS_KEY --etcd-s3-secret-key=SECRET_KEY --cluster-reset-restore-path=SNAPSHOT_PATH && sudo reboot
 # remove db on other server nodes

--- a/keys.tf
+++ b/keys.tf
@@ -1,10 +1,16 @@
+locals {
+  ssh_authorized_keys_loaded = [for key in var.ssh_authorized_keys : startswith(key, "/") || startswith(key, "~") ? file(key) : key]
+  ssh_authorized_key         = local.ssh_authorized_keys_loaded[0]
+  ssh_authorized_keys        = slice(local.ssh_authorized_keys_loaded, 1, length(local.ssh_authorized_keys_loaded))
+}
+
 resource "random_string" "rke2_token" {
   length = 64
 }
 
 resource "openstack_compute_keypair_v2" "key" {
   name       = "${var.name}-key"
-  public_key = file(var.ssh_public_key_file)
+  public_key = local.ssh_authorized_key
 }
 
 resource "null_resource" "write_kubeconfig" {

--- a/main.tf
+++ b/main.tf
@@ -19,10 +19,11 @@ module "servers" {
     server.name => server
   }
 
-  name      = "${var.name}-${each.value.name}"
-  is_server = true
-  is_first  = var.servers[0].name == each.value.name
-  bootstrap = var.bootstrap
+  name         = "${var.name}-${each.value.name}"
+  is_server    = true
+  is_first     = var.servers[0].name == each.value.name
+  is_persisted = length(var.servers) == 1
+  bootstrap    = var.bootstrap
 
   nodes_count      = 1
   flavor_name      = each.value.flavor_name
@@ -41,13 +42,15 @@ module "servers" {
 
   s3 = local.s3
 
-  system_user  = each.value.system_user
-  keypair_name = openstack_compute_keypair_v2.key.name
+  system_user         = each.value.system_user
+  keypair_name        = openstack_compute_keypair_v2.key.name
+  ssh_authorized_keys = local.ssh_authorized_keys
 
   network_id   = openstack_networking_network_v2.net.id
   subnet_id    = openstack_networking_subnet_v2.servers.id
   secgroup_id  = openstack_networking_secgroup_v2.server.id
   bootstrap_ip = local.internal_ip
+  bastion_host = local.external_ip
   san          = [local.internal_ip, local.external_ip]
 
   manifests_folder = var.manifests_folder
@@ -112,10 +115,11 @@ module "agents" {
     agent.name => agent
   }
 
-  name      = "${var.name}-${each.value.name}"
-  is_server = false
-  is_first  = false
-  bootstrap = false
+  name         = "${var.name}-${each.value.name}"
+  is_server    = false
+  is_first     = false
+  is_persisted = false
+  bootstrap    = false
 
   nodes_count      = each.value.nodes_count
   flavor_name      = each.value.flavor_name
@@ -132,8 +136,9 @@ module "agents" {
   rke2_volume_size = each.value.rke2_volume_size
   rke2_volume_type = each.value.rke2_volume_type
 
-  system_user  = each.value.system_user
-  keypair_name = openstack_compute_keypair_v2.key.name
+  system_user         = each.value.system_user
+  keypair_name        = openstack_compute_keypair_v2.key.name
+  ssh_authorized_keys = local.ssh_authorized_keys
 
   network_id   = openstack_networking_network_v2.net.id
   subnet_id    = openstack_networking_subnet_v2.agents.id

--- a/manifests/cloud-controller-openstack.yml.tpl
+++ b/manifests/cloud-controller-openstack.yml.tpl
@@ -10,9 +10,6 @@ spec:
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-
-    image:
-      repository: docker.io/k8scloudprovider/openstack-cloud-controller-manager
-      tag: "v1.26.2"
     nodeSelector:
       node-role.kubernetes.io/master: "true"
     tolerations:

--- a/manifests/csi-cinder.yml.tpl
+++ b/manifests/csi-cinder.yml.tpl
@@ -12,65 +12,37 @@ spec:
   valuesContent: |-
     csi:
       attacher:
-        image:
-          repository: k8s.gcr.io/sig-storage/csi-attacher
-          tag: v4.0.0
-          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 20m
             memory: 32M
       provisioner:
         topology: "true"
-        image:
-          repository: k8s.gcr.io/sig-storage/csi-provisioner
-          tag: v3.4.0
-          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 20m
             memory: 32M
       snapshotter:
-        image:
-          repository: k8s.gcr.io/sig-storage/csi-snapshotter
-          tag: v6.1.0
-          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 20m
             memory: 32M
       resizer:
-        image:
-          repository: k8s.gcr.io/sig-storage/csi-resizer
-          tag: v1.6.0
-          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 20m
             memory: 32M
       livenessprobe:
-        image:
-          repository: k8s.gcr.io/sig-storage/livenessprobe
-          tag: v2.8.0
-          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 20m
             memory: 32M
       nodeDriverRegistrar:
-        image:
-          repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-          tag: v2.6.2
-          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 20m
             memory: 32M
       plugin:
-        image:
-          repository: docker.io/k8scloudprovider/cinder-csi-plugin
-          tag: "v1.26.2"
-          pullPolicy: IfNotPresent
         nodePlugin:
           tolerations: []
         controllerPlugin:

--- a/manifests/ha.yml
+++ b/manifests/ha.yml
@@ -1,0 +1,54 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-coredns
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    nodeSelector:
+      node-role.kubernetes.io/master: "true"
+
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-metrics-server
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    nodeSelector:
+      node-role.kubernetes.io/master: "true"
+    tolerations:
+      - effect: NoExecute
+        key: CriticalAddonsOnly
+        operator: "Exists"
+
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-snapshot-controller
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    nodeSelector:
+      node-role.kubernetes.io/master: "true"
+    tolerations:
+      - effect: NoExecute
+        key: CriticalAddonsOnly
+        operator: "Exists"
+
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-snapshot-validation-webhook
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    nodeSelector:
+      node-role.kubernetes.io/master: "true"
+    tolerations:
+      - effect: NoExecute
+        key: CriticalAddonsOnly
+        operator: "Exists"

--- a/node/cloud-init.yml.tpl
+++ b/node/cloud-init.yml.tpl
@@ -72,7 +72,6 @@ write_files:
     server: https://${bootstrap_ip}:9345
     %{~ endif ~}
     node-ip: ${node_ip}
-    node-external-ip: ${bootstrap_ip}
     advertise-address: ${node_ip}
     write-kubeconfig-mode: "0640"
     tls-san:
@@ -86,6 +85,7 @@ write_files:
     etcd-s3-bucket: ${s3_bucket}
     etcd-snapshot-compress: true
       %{~ endif ~}
+    cloud-provider-name: external
     disable-cloud-controller: true
     disable: rke2-ingress-nginx
     disable-kube-proxy: true

--- a/node/hooks.tf
+++ b/node/hooks.tf
@@ -19,8 +19,10 @@ resource "null_resource" "agent_remove" {
     when       = destroy
     on_failure = continue
     inline = [
-      "sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml drain ${lower(self.triggers.name)} --ignore-daemonsets --delete-emptydir-data --timeout=60s; sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml delete node ${lower(self.triggers.name)}"
+      "sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml drain ${lower(self.triggers.name)} --ignore-daemonsets --delete-emptydir-data --timeout=60s || true",
+      "sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml delete node ${lower(self.triggers.name)}"
     ]
   }
 
 }
+

--- a/node/variables.tf
+++ b/node/variables.tf
@@ -10,6 +10,10 @@ variable "is_first" {
   type = bool
 }
 
+variable "is_persisted" {
+  type = bool
+}
+
 variable "bootstrap" {
   type = bool
 }
@@ -66,8 +70,7 @@ variable "bootstrap_ip" {
 }
 
 variable "bastion_host" {
-  type    = string
-  default = ""
+  type = string
 }
 
 variable "system_user" {
@@ -125,4 +128,8 @@ variable "manifests" {
 
 variable "ff_autoremove_agent" {
   type = bool
+}
+
+variable "ssh_authorized_keys" {
+  type = list(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,9 @@ variable "name" {
   type = string
 }
 
-variable "ssh_public_key_file" {
-  type    = string
-  default = "~/.ssh/id_rsa.pub"
+variable "ssh_authorized_keys" {
+  type    = list(string)
+  default = ["~/.ssh/id_rsa.pub"]
 }
 
 variable "floating_pool" {


### PR DESCRIPTION
Switching the cloud provider to external, allow the openstack controller to query the node status and perform additional check.

Caveat: the current terraform provider does not support to have a volume and an instance "synchronised" together (as this create a cycle).

See https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1545 or https://github.com/hashicorp/terraform/issues/31707.