### PR TITLE
Support rke2 volume device and lb type configuration

### DIFF
--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -10,7 +10,7 @@ resource "openstack_lb_loadbalancer_v2" "lb" {
   vip_network_id        = openstack_networking_network_v2.net.id
   vip_address           = local.internal_ip
   admin_state_up        = "true"
-  loadbalancer_provider = "octavia"
+  loadbalancer_provider = "${var.lb_provider}"
 
   depends_on = [
     openstack_networking_subnet_v2.lb

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ module "servers" {
   rke2_token       = random_string.rke2_token.result
   rke2_volume_size = each.value.rke2_volume_size
   rke2_volume_type = each.value.rke2_volume_type
+  rke2_volume_dev  = each.value.rke2_volume_dev
 
   s3 = local.s3
 
@@ -85,6 +86,7 @@ module "servers" {
         network_id          = openstack_networking_network_v2.net.id
         subnet_id           = openstack_networking_subnet_v2.lb.id
         floating_network_id = data.openstack_networking_network_v2.floating_net.id
+        lb_provider         = var.lb_provider
         cluster_name        = var.name
       }),
       "cilium.yml" : templatefile("${path.module}/manifests/cilium.yml.tpl", {
@@ -140,6 +142,7 @@ module "agents" {
   rke2_token       = random_string.rke2_token.result
   rke2_volume_size = each.value.rke2_volume_size
   rke2_volume_type = each.value.rke2_volume_type
+  rke2_volume_dev = each.value.rke2_volume_dev
 
   system_user         = each.value.system_user
   keypair_name        = openstack_compute_keypair_v2.key.name

--- a/main.tf
+++ b/main.tf
@@ -35,12 +35,12 @@ module "servers" {
   availability_zones = coalesce(each.value.availability_zones, [])
   affinity           = coalesce(each.value.affinity, "soft-anti-affinity")
 
-  rke2_version     = each.value.rke2_version
-  rke2_config      = each.value.rke2_config
-  rke2_token       = random_string.rke2_token.result
-  rke2_volume_size = each.value.rke2_volume_size
-  rke2_volume_type = each.value.rke2_volume_type
-  rke2_volume_dev  = each.value.rke2_volume_dev
+  rke2_version        = each.value.rke2_version
+  rke2_config         = each.value.rke2_config
+  rke2_token          = random_string.rke2_token.result
+  rke2_volume_size    = each.value.rke2_volume_size
+  rke2_volume_type    = each.value.rke2_volume_type
+  rke2_volume_device  = each.value.rke2_volume_device
 
   s3 = local.s3
 
@@ -137,12 +137,12 @@ module "agents" {
   availability_zones = coalesce(each.value.availability_zones, [])
   affinity           = coalesce(each.value.affinity, "soft-anti-affinity")
 
-  rke2_version     = each.value.rke2_version
-  rke2_config      = each.value.rke2_config
-  rke2_token       = random_string.rke2_token.result
-  rke2_volume_size = each.value.rke2_volume_size
-  rke2_volume_type = each.value.rke2_volume_type
-  rke2_volume_dev = each.value.rke2_volume_dev
+  rke2_version       = each.value.rke2_version
+  rke2_config        = each.value.rke2_config
+  rke2_token         = random_string.rke2_token.result
+  rke2_volume_size   = each.value.rke2_volume_size
+  rke2_volume_type   = each.value.rke2_volume_type
+  rke2_volume_device = each.value.rke2_volume_device
 
   system_user         = each.value.system_user
   keypair_name        = openstack_compute_keypair_v2.key.name

--- a/manifests/cloud-controller-openstack.yml.tpl
+++ b/manifests/cloud-controller-openstack.yml.tpl
@@ -37,7 +37,7 @@ spec:
         %{~ endif ~}
         subnet-id: ${subnet_id}
         network-id: ${network_id}
-        lb-provider: octavia
+        lb-provider: ${lb_provider}
         manage-security-groups: true
         max-shared-lb: 10
     controllerExtraArgs: |-

--- a/node/cloud-init.yml.tpl
+++ b/node/cloud-init.yml.tpl
@@ -9,9 +9,9 @@ growpart:
 fs_setup:
   - label: None
     filesystem: ext4
-    device: /dev/sdb
+    device: ${rke2_device}
 mounts:
-  - ["/dev/sdb", "/var/lib/rancher/rke2", "ext4", "defaults,nofail", "0", "2"]
+  - [${rke2_device}, "/var/lib/rancher/rke2", "ext4", "defaults,nofail", "0", "2"]
 
 package_update: true
 package_upgrade: true

--- a/node/main.tf
+++ b/node/main.tf
@@ -79,7 +79,7 @@ resource "openstack_compute_instance_v2" "instance" {
     rke2_token   = var.rke2_token
     rke2_version = var.rke2_version
     rke2_conf    = var.rke2_config != null ? var.rke2_config : ""
-    rke2_device  = var.rke2_volume_dev
+    rke2_device  = var.rke2_volume_device
     is_server    = var.is_server
     is_first     = var.is_first && count.index == 0
     bootstrap    = var.bootstrap && var.is_first && count.index == 0

--- a/node/main.tf
+++ b/node/main.tf
@@ -79,6 +79,7 @@ resource "openstack_compute_instance_v2" "instance" {
     rke2_token   = var.rke2_token
     rke2_version = var.rke2_version
     rke2_conf    = var.rke2_config != null ? var.rke2_config : ""
+    rke2_device  = var.rke2_volume_dev
     is_server    = var.is_server
     is_first     = var.is_first && count.index == 0
     bootstrap    = var.bootstrap && var.is_first && count.index == 0

--- a/node/variables.tf
+++ b/node/variables.tf
@@ -105,6 +105,10 @@ variable "rke2_volume_type" {
   type = string
 }
 
+variable "rke2_volume_dev" {
+  type = string
+}
+
 variable "s3" {
   type = object({
     endpoint      = string

--- a/node/variables.tf
+++ b/node/variables.tf
@@ -105,8 +105,10 @@ variable "rke2_volume_type" {
   type = string
 }
 
-variable "rke2_volume_dev" {
-  type = string
+variable "rke2_volume_device" {
+  type     = string
+  default  = "/dev/sda"
+  nullable = false
 }
 
 variable "s3" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,11 @@ variable "dns_nameservers4" {
   default = ["1.1.1.1", "1.0.0.1"]
 }
 
+variable "lb_provider" {
+  type = string
+  default = "octavia"
+}
+
 variable "bootstrap" {
   type    = bool
   default = false
@@ -105,6 +110,7 @@ variable "servers" {
     rke2_config        = optional(string)
     rke2_volume_size   = number
     rke2_volume_type   = optional(string)
+    rke2_volume_dev    = optional(string)
   }))
   validation {
     condition = (
@@ -136,6 +142,7 @@ variable "agents" {
     rke2_config        = optional(string)
     rke2_volume_size   = number
     rke2_volume_type   = optional(string)
+    rke2_volume_dev    = optional(string)
   }))
   validation {
     condition = (

--- a/variables.tf
+++ b/variables.tf
@@ -86,8 +86,9 @@ variable "dns_nameservers4" {
 }
 
 variable "lb_provider" {
-  type = string
-  default = "octavia"
+  type     = string
+  default  = "octavia"
+  nullable = false
 }
 
 variable "bootstrap" {
@@ -110,7 +111,7 @@ variable "servers" {
     rke2_config        = optional(string)
     rke2_volume_size   = number
     rke2_volume_type   = optional(string)
-    rke2_volume_dev    = optional(string)
+    rke2_volume_device = optional(string)
   }))
   validation {
     condition = (
@@ -142,7 +143,7 @@ variable "agents" {
     rke2_config        = optional(string)
     rke2_volume_size   = number
     rke2_volume_type   = optional(string)
-    rke2_volume_dev    = optional(string)
+    rke2_volume_device = optional(string)
   }))
   validation {
     condition = (


### PR DESCRIPTION
Thanks for providing this awesome terraform module! We used RKE1 in our OpenStack private cloud as well as custom k3s and remche/terraform-openstack-rke2 installations for courses in our university, but your repo is the perfect fit regarding complexity and flexibility.

This PR contains a small suggestion to make the name of the loadbalancer driver as well as the block device used for the rke2 volume configurable.

In our (and supposedly a lot of other) OpenStack environments, block devices in the instances are not getting /dev/sdX but thanks to virtio (usually faster, paravirtualized) disk devices /dev/vdX. Therefore, your cloud-init template fails to create and extend the rke2 volume. The PR introduces rke2_volume_device that can be used to specify the device to look for in the instance (in our case /dev/vda, but /dev/sda stays the default).

Also, the octavia load balancer driver using the PR can be changed. It's really strange, that Infomaniak uses "octavia" as the driver name. The entire load balancer service in OpenStack is named "octavia" but this is not a standard name for the driver (https://docs.openstack.org/octavia/latest/admin/providers/index.html) which is "amphora" by default, also in our private cloud environment.

Consequently, maybe these configuration options are also of value for other OpenStack cloud providers.

Thanks again for your work and the elegant terraform module!