### PR TITLE
feat: ha/lb features with kube-vip and minor fixes

### DIFF
--- a/keys.tf
+++ b/keys.tf
@@ -35,13 +35,13 @@ resource "null_resource" "write_kubeconfig" {
       ssh-keygen -R ${local.external_ip} >/dev/null 2>&1
       until rsync -e "ssh -o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" --rsync-path="sudo rsync" ${var.servers[0].system_user}@${local.external_ip}:/etc/rancher/rke2/rke2.yaml rke2.yaml >/dev/null 2>&1; do echo Wait rke2.yaml generation && sleep 5; done \
       && chmod go-r rke2.yaml \
-      && yq eval --inplace '.clusters[0].name = "${var.name}-cluster"' rke2.yaml \
-      && yq eval --inplace '.clusters[0].cluster.server = "https://${local.external_ip}:6443"' rke2.yaml \
-      && yq eval --inplace '.users[0].name = "${var.name}-user"' rke2.yaml \
-      && yq eval --inplace '.contexts[0].context.cluster = "${var.name}-cluster"' rke2.yaml \
-      && yq eval --inplace '.contexts[0].context.user = "${var.name}-user"' rke2.yaml \
-      && yq eval --inplace '.contexts[0].name = "${var.name}"' rke2.yaml \
-      && yq eval --inplace '.current-context = "${var.name}"' rke2.yaml \
+      && python3 -m yq -y --in-place '.clusters[0].name = "${var.name}-cluster"' rke2.yaml \
+      && python3 -m yq -y --in-place '.clusters[0].cluster.server = "https://${local.external_ip}:6443"' rke2.yaml \
+      && python3 -m yq -y --in-place '.users[0].name = "${var.name}-user"' rke2.yaml \
+      && python3 -m yq -y --in-place '.contexts[0].context.cluster = "${var.name}-cluster"' rke2.yaml \
+      && python3 -m yq -y --in-place '.contexts[0].context.user = "${var.name}-user"' rke2.yaml \
+      && python3 -m yq -y --in-place '.contexts[0].name = "${var.name}"' rke2.yaml \
+      && python3 -m yq -y --in-place '."current-context" = "${var.name}"' rke2.yaml \
       && mv rke2.yaml ${var.name}.rke2.yaml
     EOF
   }

--- a/keys.tf
+++ b/keys.tf
@@ -32,16 +32,19 @@ resource "null_resource" "write_kubeconfig" {
 
   provisioner "local-exec" {
     command = <<EOF
+      # This should work with fish and bash (eval is being used to trick the parser/interpreter which checks the line before actually running it)
+      [ "$fish_pid" != "" ] && eval 'set YQ_BIN (begin; which yq &> /dev/null && echo yq; end || begin; python -m yq --help &> /dev/null && echo python -m yq; end)' || eval 'YQ_BIN=$((which yq &> /dev/null && echo yq) || (python -m yq --help &> /dev/null && echo python -m yq))'
+
       ssh-keygen -R ${local.external_ip} >/dev/null 2>&1
       until rsync -e "ssh -o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" --rsync-path="sudo rsync" ${var.servers[0].system_user}@${local.external_ip}:/etc/rancher/rke2/rke2.yaml rke2.yaml >/dev/null 2>&1; do echo Wait rke2.yaml generation && sleep 5; done \
       && chmod go-r rke2.yaml \
-      && python3 -m yq -y --in-place '.clusters[0].name = "${var.name}-cluster"' rke2.yaml \
-      && python3 -m yq -y --in-place '.clusters[0].cluster.server = "https://${local.external_ip}:6443"' rke2.yaml \
-      && python3 -m yq -y --in-place '.users[0].name = "${var.name}-user"' rke2.yaml \
-      && python3 -m yq -y --in-place '.contexts[0].context.cluster = "${var.name}-cluster"' rke2.yaml \
-      && python3 -m yq -y --in-place '.contexts[0].context.user = "${var.name}-user"' rke2.yaml \
-      && python3 -m yq -y --in-place '.contexts[0].name = "${var.name}"' rke2.yaml \
-      && python3 -m yq -y --in-place '."current-context" = "${var.name}"' rke2.yaml \
+      && $YQ_BIN -y --in-place '.clusters[0].name = "${var.name}-cluster"' rke2.yaml \
+      && $YQ_BIN -y --in-place '.clusters[0].cluster.server = "https://${local.external_ip}:6443"' rke2.yaml \
+      && $YQ_BIN -y --in-place '.users[0].name = "${var.name}-user"' rke2.yaml \
+      && $YQ_BIN -y --in-place '.contexts[0].context.cluster = "${var.name}-cluster"' rke2.yaml \
+      && $YQ_BIN -y --in-place '.contexts[0].context.user = "${var.name}-user"' rke2.yaml \
+      && $YQ_BIN -y --in-place '.contexts[0].name = "${var.name}"' rke2.yaml \
+      && $YQ_BIN -y --in-place '."current-context" = "${var.name}"' rke2.yaml \
       && mv rke2.yaml ${var.name}.rke2.yaml
     EOF
   }

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ module "servers" {
         operator_replica = local.operator_replica
       }),
       "kube-vip.yml" : templatefile("${path.module}/manifests/kube-vip.yml.tpl", {
-        vip_address = "192.168.44.5"
+        vip_address = local.internal_ip
       })
     },
     {

--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,9 @@ module "servers" {
       "ha.yml" : templatefile("${path.module}/manifests/ha.yml.tpl", {
         operator_replica = local.operator_replica
       }),
+      "kube-vip.yml" : templatefile("${path.module}/manifests/kube-vip.yml.tpl", {
+        vip_address = "192.168.44.5"
+      })
     },
     {
       for f in fileset(path.module, "manifests/*.{yml,yaml}") : basename(f) => file("${path.module}/${f}")

--- a/manifests/kube-vip.yml.tpl
+++ b/manifests/kube-vip.yml.tpl
@@ -1,0 +1,47 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: kube-vip
+  namespace: kube-system
+spec:
+  chart: kube-vip
+  repo: "https://kube-vip.github.io/helm-charts"
+  version: 0.4.4
+  targetNamespace: kube-system
+  bootstrap: true
+  valuesContent: |-
+    image:
+      repository: ghcr.io/kube-vip/kube-vip
+      pullPolicy: IfNotPresent
+      tag: "v0.6.2"
+
+    config:
+      address: ${vip_address}
+
+    env:
+      vip_interface: ens3
+      vip_arp: "true"
+      lb_enable: "true"
+      lb_port: "6443"
+      vip_cidr: "32"
+      cp_enable: "true"
+      cp_namespace: "kube-system"
+      vip_ddns: "false"
+      svc_enable: "false"
+      svc_election: "false"
+      vip_leaderelection: "true"
+
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        memory: 256Mi
+
+    tolerations:
+      - effect: NoExecute
+        key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: "Exists"

--- a/node/cloud-init.yml.tpl
+++ b/node/cloud-init.yml.tpl
@@ -129,7 +129,6 @@ runcmd:
   - echo "${key}" >> /home/${system_user}/.ssh/authorized_keys
   %{~ endfor ~}
   - /usr/local/bin/install-or-upgrade-rke2.sh
-  - mod
   - echo 'alias crictl="sudo /var/lib/rancher/rke2/bin/crictl -r unix:///run/k3s/containerd/containerd.sock"' >> /home/${system_user}/.bashrc
   %{~ if is_server ~}
   - echo 'alias kubectl="sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml"' >> /home/${system_user}/.bashrc

--- a/node/cloud-init.yml.tpl
+++ b/node/cloud-init.yml.tpl
@@ -43,6 +43,13 @@ write_files:
   owner: root:root
   content: | 
     maxsize 500M
+- path: /etc/modules-load.d/ipvs.conf
+  permissions: "0644"
+  owner: root:root
+  content: |
+    # Loads kernel modules needed for kube-vip to work properly
+    ip_vs
+    ip_vs_rr
 - path: /usr/local/bin/wait-for-node-ready.sh
   permissions: "0755"
   owner: root:root
@@ -122,6 +129,7 @@ runcmd:
   - echo "${key}" >> /home/${system_user}/.ssh/authorized_keys
   %{~ endfor ~}
   - /usr/local/bin/install-or-upgrade-rke2.sh
+  - mod
   - echo 'alias crictl="sudo /var/lib/rancher/rke2/bin/crictl -r unix:///run/k3s/containerd/containerd.sock"' >> /home/${system_user}/.bashrc
   %{~ if is_server ~}
   - echo 'alias kubectl="sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml"' >> /home/${system_user}/.bashrc


### PR DESCRIPTION
Feature using kube-vip for VIP, modules need for kube-vip to work properly are being loaded using systemd for now (**ip_vs** and **ip_vs_rr**). 
Fixed the command that modifies the yaml file for kubectl. It's being used as a python3 module/program (which it is), but it's easily reversible if needed/wanted.