### PR TITLE
feat: expore the server group configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/tofuutils/pre-commit-opentofu
-    rev: 65ac74a0fd483b19b93293918c088067a9979e6d
+    rev: v1.0.2
     hooks:
       - id: tofu_fmt
       - id: tofu_checkov

--- a/node/main.tf
+++ b/node/main.tf
@@ -3,11 +3,6 @@ data "openstack_images_image_v2" "image" {
   most_recent = true
 }
 
-resource "openstack_compute_servergroup_v2" "servergroup" {
-  name     = "${var.name}-servergroup"
-  policies = [var.affinity]
-}
-
 resource "openstack_blockstorage_volume_v3" "volume" {
   count                = var.is_persisted ? var.nodes_count : 0
   name                 = "${var.name}-${count.index + 1}-rke2"
@@ -53,7 +48,7 @@ resource "openstack_compute_instance_v2" "instance" {
   }
 
   scheduler_hints {
-    group = openstack_compute_servergroup_v2.servergroup.id
+    group = var.group_id
   }
 
   metadata = {

--- a/node/variables.tf
+++ b/node/variables.tf
@@ -47,7 +47,7 @@ variable "availability_zones" {
   type = list(string)
 }
 
-variable "affinity" {
+variable "group_id" {
   type = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -109,7 +109,7 @@ variable "bootstrap" {
 variable "servers" {
   type = list(object({
     name               = string
-    affinity           = optional(string)
+    group_id           = optional(string)
     availability_zones = optional(list(string))
     flavor_name        = string
     image_name         = string
@@ -141,7 +141,7 @@ variable "agents" {
   type = list(object({
     name               = string
     nodes_count        = number
-    affinity           = optional(string)
+    group_id           = optional(string)
     availability_zones = optional(list(string))
     flavor_name        = string
     image_name         = string


### PR DESCRIPTION
previously only the affinity policies of Openstack were exposed for each node pool, now explicit server group can be given, and by default all the servers are in a single hard anti-affinity and the agents in a single soft anti-affinity