### PR TITLE
fix: edge case for empty rke2 chart

### DIFF
--- a/node/cloud-init.yaml.tpl
+++ b/node/cloud-init.yaml.tpl
@@ -124,7 +124,7 @@ write_files:
     ls $CHARTS_DIR
     for patch in /opt/rke2/manifests/patches/*; do
       patch_name=$(basename "$patch")
-      if [ -f "$CHARTS_DIR/$patch_name" ]; then
+      if [ -f "$CHARTS_DIR/$patch_name" ] && [ "$(yq e 'length' ""$CHARTS_DIR/$patch_name")" -ne "0" ]; then
         /usr/local/bin/customize-chart.sh "$CHARTS_DIR/$patch_name" "$patch"
       fi
     done


### PR DESCRIPTION
When helm chart shipped inside rke2 have only comment inside, like

https://github.com/rancher/rke2/blob/ef0fc7aa9d3bbaa95ce9b1895972488cbd92e302/charts/chart_versions.yaml#L53
https://github.com/rancher/rke2/blob/ef0fc7aa9d3bbaa95ce9b1895972488cbd92e302/charts/build-chart.sh#L22-L25

applying patch to it would produce incorrect HelmChart manifest, as such controller would try to install it anyway, in an endless loop.
So we would prevent patching, by checking it's not empty.
