### PR TITLE
fix: mnt.mount unit ordering cycle

### DIFF
--- a/node/cloud-init.yaml.tpl
+++ b/node/cloud-init.yaml.tpl
@@ -44,7 +44,8 @@ write_files:
 - path: /etc/systemd/system/mnt.mount
   content: |
     [Unit]
-    After=local-fs.target
+    After=local-fs-pre.target
+    Before=local-fs.target
     [Mount]
     What=${rke2_device}
     Where=/mnt


### PR DESCRIPTION
due to mnt.mount originaly `After=local-fs.target` - it creates ordering cycle due to

> Mount units referring to local file systems automatically gain an After= dependency on local-fs-pre.target, and a Before= dependency on local-fs.target unless one or more mount options among nofail, x-systemd.wanted-by=, and x-systemd.required-by= is set.

https://www.freedesktop.org/software/systemd/man/latest/systemd.mount.html

```
Sep 22 22:15:33 k8s-master-1 systemd[1]: local-fs.target: Found ordering cycle on mnt.mount/stop
Sep 22 22:15:33 k8s-master-1 systemd[1]: local-fs.target: Job mnt.mount/stop deleted to break ordering cycle starting with local-fs.target/stop
Sep 22 22:17:19 k8s-master-1 systemd[1]: local-fs.target: Found dependency on mnt.mount/start
Sep 22 22:17:19 k8s-master-1 systemd[1]: local-fs.target: Found ordering cycle on mnt.mount/start
Sep 22 22:17:19 k8s-master-1 systemd[1]: local-fs.target: Job mnt.mount/start deleted to break ordering cycle starting with local-fs.target/start
Sep 24 13:02:47 k8s-master-1 systemd[1]: local-fs.target: Found dependency on mnt.mount/start
Sep 24 13:02:47 k8s-master-1 systemd[1]: local-fs.target: Found ordering cycle on mnt.mount/start
Sep 24 13:02:47 k8s-master-1 systemd[1]: local-fs.target: Job mnt.mount/start deleted to break ordering cycle starting with local-fs.target/start
```