### PR TITLE
bumped tested versions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ defaults for running production workload.
 
 | Component                  | Version                                                                                                                  |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| OpenStack                  | 2023.1 Antelope (verified), maybe older version are supported too                                                        |
-| RKE2                       | [v1.31.14+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.31.14+rke2r1)                                          |
-| OpenStack Cloud Controller | [v1.34.1](https://github.com/kubernetes/cloud-provider-openstack/tree/v1.34.1/charts/openstack-cloud-controller-manager) |
-| OpenStack Cinder           | [v1.34.1](https://github.com/kubernetes/cloud-provider-openstack/tree/v1.34.1/charts/cinder-csi-plugin)                  |
-| Velero                     | [v6.0.0](https://github.com/vmware-tanzu/helm-charts/tree/velero-6.0.0/charts/velero)                                    |
+| OpenStack                  | 2024.1 Caracal (verified), maybe older version are supported too                                                         |
+| RKE2                       | [v1.35.4+rke2r1](https://github.com/rancher/rke2/releases/tag/v1.35.4+rke2r1)                                            |
+| OpenStack Cloud Controller | [v2.34.1](https://github.com/kubernetes/cloud-provider-openstack/releases/tag/openstack-cloud-controller-manager-2.34.1) |
+| OpenStack Cinder           | [v2.34.1](https://github.com/kubernetes/cloud-provider-openstack/releases/tag/openstack-cinder-csi-2.34.1)               |
+| Velero                     | [v11.3.2](https://github.com/vmware-tanzu/helm-charts/releases/tag/velero-11.3.2)                                        |
 | Kube-vip                   | [v0.7.2](https://github.com/kube-vip/kube-vip/releases/tag/v0.7.2)                                                       |
 
 ## Getting started


### PR DESCRIPTION
Thanks again for your excellent work and the repository! We still use it for our courses at Fulda University of Applied Sciences!

Thanks to your changes to the handling of taints, I tested using more recent k8s / rke2 versions today, especially as 1.30 and up to 1.32 are already EOL (though still frequently used). I was able to successfully deploy up to most recent version [v1.35.4+rke2r1](https://docs.rke2.io/release-notes/v1.35.X#release-v1354rke2r1), so maybe you want to update the README