### PR TITLE
fixed lb created for k8s workloads not being reachable anymore

### DIFF
--- a/manifests/cloud-controller-openstack.yaml.tpl
+++ b/manifests/cloud-controller-openstack.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart: openstack-cloud-controller-manager
   repo: https://kubernetes.github.io/cloud-provider-openstack
-  version: 2.34.1
+  version: 2.35.0
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-

--- a/manifests/csi-cinder.yaml.tpl
+++ b/manifests/csi-cinder.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart: openstack-cinder-csi
   repo: https://kubernetes.github.io/cloud-provider-openstack
-  version: 2.34.1
+  version: 2.35.0
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-

--- a/secgroup.tf
+++ b/secgroup.tf
@@ -149,3 +149,13 @@ resource "openstack_networking_secgroup_rule_v2" "agent_agent" {
   remote_group_id   = openstack_networking_secgroup_v2.agent.id
   security_group_id = openstack_networking_secgroup_v2.agent.id
 }
+
+resource "openstack_networking_secgroup_rule_v2" "lb_agent_nodeport_range" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = var.subnet_lb_cidr
+  security_group_id = openstack_networking_secgroup_v2.agent.id
+}


### PR DESCRIPTION
Load Balancers created by openstack-cloud-controller-manager were not reachable anymore. Load Balancers were created and online/active incl. all dependencies and floating IP without errors, but accessing the service using the floating IP timed out. 

After some investigation, and detecting that the services behind the load balancer were instantly accessible after temporarily turning off port security, the solution was to allow the node ports to be accessible from the lb network. They are also required to be reachable according to RKE2 docu (https://docs.rke2.io/install/requirements#inbound-network-rules). 

We didn't experience this issue in previous versions of terraform-openstack-rke2, but it seems like something has changed in OpenStack, rke2 or terraform-openstack-rke2 to now require this rule.

Also bumped openstack cloud controller manager and cinder csi version to 2.35.