### PR TITLE
feat!: auto-interface and ovn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,6 @@ spec:
           value: "true"
         - name: port
           value: "6443"
-        - name: vip_interface
-          value: ens3
         - name: vip_cidr
           value: "32"
         - name: cp_enable

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
     access_key    = openstack_identity_ec2_credential_v3.s3[0].access
     access_secret = openstack_identity_ec2_credential_v3.s3[0].secret
     bucket        = openstack_objectstorage_container_v1.etcd_snapshots[0].name
+    region        = var.object_store_region
   } : var.s3_backup
 
   external_ip      = openstack_networking_floatingip_v2.floating_ip.address
@@ -61,16 +62,15 @@ module "servers" {
   keypair_name        = openstack_compute_keypair_v2.key.name
   ssh_authorized_keys = local.ssh_authorized_keys
 
-  network_id    = openstack_networking_network_v2.net.id
-  subnet_id     = openstack_networking_subnet_v2.servers.id
-  cluster_cidr  = var.cluster_cidr
-  service_cidr  = var.service_cidr
-  cni           = var.cni
-  secgroup_id   = openstack_networking_secgroup_v2.server.id
-  internal_vip  = local.internal_vip
-  vip_interface = var.vip_interface
-  bastion_host  = local.external_ip
-  san           = distinct(concat([local.external_ip, local.internal_vip], var.additional_san))
+  network_id   = openstack_networking_network_v2.net.id
+  subnet_id    = openstack_networking_subnet_v2.servers.id
+  cluster_cidr = var.cluster_cidr
+  service_cidr = var.service_cidr
+  cni          = var.cni
+  secgroup_id  = openstack_networking_secgroup_v2.server.id
+  internal_vip = local.internal_vip
+  bastion_host = local.external_ip
+  san          = distinct(concat([local.external_ip, local.internal_vip], var.additional_san))
 
   manifests_folder = var.manifests_folder
   manifests = merge(
@@ -101,7 +101,7 @@ module "servers" {
         app_secret          = openstack_identity_application_credential_v3.rke2.secret
         app_name            = openstack_identity_application_credential_v3.rke2.name
         network_id          = openstack_networking_network_v2.net.id
-        subnet_id           = openstack_networking_subnet_v2.lb.id
+        subnet_id           = openstack_networking_subnet_v2.agents.id
         floating_network_id = data.openstack_networking_network_v2.floating_net.id
         lb_provider         = var.lb_provider
         cluster_name        = var.name
@@ -208,15 +208,14 @@ module "agents" {
   keypair_name        = openstack_compute_keypair_v2.key.name
   ssh_authorized_keys = local.ssh_authorized_keys
 
-  network_id    = openstack_networking_network_v2.net.id
-  subnet_id     = openstack_networking_subnet_v2.agents.id
-  cluster_cidr  = var.cluster_cidr
-  service_cidr  = var.service_cidr
-  cni           = var.cni
-  secgroup_id   = openstack_networking_secgroup_v2.agent.id
-  internal_vip  = local.internal_vip
-  vip_interface = var.vip_interface
-  bastion_host  = local.external_ip
+  network_id   = openstack_networking_network_v2.net.id
+  subnet_id    = openstack_networking_subnet_v2.agents.id
+  cluster_cidr = var.cluster_cidr
+  service_cidr = var.service_cidr
+  cni          = var.cni
+  secgroup_id  = openstack_networking_secgroup_v2.agent.id
+  internal_vip = local.internal_vip
+  bastion_host = local.external_ip
 
   ff_autoremove_agent = var.ff_autoremove_agent
   ff_wait_ready       = var.ff_wait_ready

--- a/manifests/cloud-controller-openstack.yaml.tpl
+++ b/manifests/cloud-controller-openstack.yaml.tpl
@@ -6,7 +6,8 @@ metadata:
 spec:
   chart: openstack-cloud-controller-manager
   repo: https://kubernetes.github.io/cloud-provider-openstack
-  version: 2.34.1
+  # https://artifacthub.io/packages/helm/cloud-provider-openstack/openstack-cloud-controller-manager
+  version: 2.36.0
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-
@@ -32,6 +33,7 @@ spec:
         floating-network-id: ${floating_network_id}
         %{~ endif ~}
         subnet-id: ${subnet_id}
+        member-subnet-id: ${subnet_id}
         network-id: ${network_id}
         lb-provider: ${lb_provider}
         manage-security-groups: true

--- a/manifests/csi-cinder.yaml.tpl
+++ b/manifests/csi-cinder.yaml.tpl
@@ -6,7 +6,8 @@ metadata:
 spec:
   chart: openstack-cinder-csi
   repo: https://kubernetes.github.io/cloud-provider-openstack
-  version: 2.34.1
+  # https://artifacthub.io/packages/helm/cloud-provider-openstack/openstack-cinder-csi
+  version: 2.36.0
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-

--- a/network.tf
+++ b/network.tf
@@ -20,6 +20,7 @@ resource "openstack_networking_subnet_v2" "agents" {
 }
 
 resource "openstack_networking_subnet_v2" "lb" {
+  count           = var.ff_lb_subnets_compat ? 1 : 0
   name            = "${var.name}-lb-subnet"
   network_id      = openstack_networking_network_v2.net.id
   cidr            = var.subnet_lb_cidr
@@ -47,8 +48,9 @@ resource "openstack_networking_router_interface_v2" "agents" {
 }
 
 resource "openstack_networking_router_interface_v2" "lb" {
+  count     = var.ff_lb_subnets_compat ? 1 : 0
   router_id = openstack_networking_router_v2.router.id
-  subnet_id = openstack_networking_subnet_v2.lb.id
+  subnet_id = openstack_networking_subnet_v2.lb[0].id
 }
 
 resource "openstack_networking_floatingip_v2" "floating_ip" {
@@ -73,4 +75,14 @@ resource "openstack_networking_port_v2" "dummy" {
     subnet_id  = openstack_networking_subnet_v2.servers.id
     ip_address = local.internal_vip
   }
+}
+
+moved {
+  from = openstack_networking_subnet_v2.lb
+  to   = openstack_networking_subnet_v2.lb[0]
+}
+
+moved {
+  from = openstack_networking_router_interface_v2.lb
+  to   = openstack_networking_router_interface_v2.lb[0]
 }

--- a/node/cloud-init.yaml.tpl
+++ b/node/cloud-init.yaml.tpl
@@ -5,10 +5,9 @@ growpart:
   mode: auto
   devices:
     - /
-    - ${rke2_device}
   ignore_growroot_disabled: false
 fs_setup:
-  - label: None
+  - label: rke2_data
     filesystem: ext4
     device: ${rke2_device}
 # no mounts as managed by systemd
@@ -47,7 +46,7 @@ write_files:
     After=local-fs-pre.target
     Before=local-fs.target
     [Mount]
-    What=${rke2_device}
+    What=/dev/disk/by-label/rke2_data
     Where=/mnt
     Type=ext4
     Options=defaults
@@ -157,8 +156,6 @@ write_files:
           value: "true"
         - name: port
           value: "6443"
-        - name: vip_interface
-          value: "${vip_interface}"
         - name: vip_cidr
           value: "32"
         - name: cp_enable
@@ -238,6 +235,9 @@ write_files:
     etcd-s3-access-key: "${s3.access_key}"
     etcd-s3-secret-key: "${s3.access_secret}"
     etcd-s3-bucket: "${s3.bucket}"
+    %{~ if s3.region != null ~}
+    etcd-s3-region: "${s3.region}"
+    %{~ endif ~}
       %{~ if backup_schedule != null ~}
     etcd-snapshot-schedule-cron: ${backup_schedule}
       %{~ endif ~}
@@ -254,7 +254,9 @@ write_files:
     %{~ endif ~}
     disable-cloud-controller: true
     disable-kube-proxy: ${ff_with_kubeproxy ? "false" : "true"}
-    disable: rke2-ingress-nginx
+    disable:
+      - rke2-ingress-nginx
+      - rke2-traefik
     cni: "${cni}"
     node-taint:
       - "node-role.kubernetes.io/control-plane:NoSchedule"
@@ -266,6 +268,9 @@ write_files:
     %{~ for k, v in node_labels ~}
       - "${k}=${v}"
     %{~ endfor ~}
+    %{~ if rke2_conf != "" ~}
+    ${ indent(4, rke2_conf) }
+    %{~ endif ~}
 %{~ else ~}
 - path: /etc/rancher/rke2/config.yaml
   permissions: "0600"
@@ -286,6 +291,9 @@ write_files:
     %{~ for k, v in node_labels ~}
       - "${k}=${v}"
     %{~ endfor ~}
+    %{~ endif ~}
+    %{~ if rke2_conf != "" ~}
+    ${ indent(4, rke2_conf) }
     %{~ endif ~}
 %{~ endif ~}
 %{~ if registries != null ~}

--- a/node/main.tf
+++ b/node/main.tf
@@ -78,20 +78,19 @@ resource "openstack_compute_instance_v2" "instance" {
 
   # yamlencode(yamldecode to debug yaml
   user_data = base64encode(templatefile("${path.module}/cloud-init.yaml.tpl", {
-    rke2_token    = var.rke2_token
-    rke2_version  = var.rke2_version
-    rke2_conf     = var.rke2_config != null ? var.rke2_config : ""
-    rke2_device   = var.rke2_volume_device
-    is_server     = var.is_server
-    is_first      = var.is_first && count.index == 0
-    bootstrap     = var.bootstrap && var.is_first && count.index == 0
-    internal_vip  = var.internal_vip
-    vip_interface = var.vip_interface
-    node_ip       = openstack_networking_port_v2.port[count.index].all_fixed_ips[0]
-    cluster_cidr  = var.cluster_cidr
-    service_cidr  = var.service_cidr
-    cni           = var.cni
-    san           = var.is_server ? var.san : []
+    rke2_token   = var.rke2_token
+    rke2_version = var.rke2_version
+    rke2_conf    = var.rke2_config != null ? var.rke2_config : ""
+    rke2_device  = var.rke2_volume_device
+    is_server    = var.is_server
+    is_first     = var.is_first && count.index == 0
+    bootstrap    = var.bootstrap && var.is_first && count.index == 0
+    internal_vip = var.internal_vip
+    node_ip      = openstack_networking_port_v2.port[count.index].all_fixed_ips[0]
+    cluster_cidr = var.cluster_cidr
+    service_cidr = var.service_cidr
+    cni          = var.cni
+    san          = var.is_server ? var.san : []
     manifests_files = var.is_server ? merge(
       var.manifests_folder != "" ? {
         for f in fileset(var.manifests_folder, "*.{yml,yaml}") : f => base64gzip(file("${var.manifests_folder}/${f}"))

--- a/node/variables.tf
+++ b/node/variables.tf
@@ -85,10 +85,6 @@ variable "internal_vip" {
   default = ""
 }
 
-variable "vip_interface" {
-  type = string
-}
-
 variable "bastion_host" {
   type = string
 }
@@ -143,12 +139,14 @@ variable "s3" {
     access_key    = string
     access_secret = string
     bucket        = string
+    region        = optional(string)
   })
   default = {
     endpoint      = ""
     access_key    = ""
     access_secret = ""
     bucket        = ""
+    region        = null
   }
 }
 

--- a/node/versions.tf
+++ b/node/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2.2"
+      version = ">= 3"
     }
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "~> 2.1.0"
+      version = ">= 3"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,8 +10,16 @@ output "network_id" {
   value = openstack_networking_network_v2.net.id
 }
 
+output "servers_subnet_id" {
+  value = openstack_networking_subnet_v2.servers.id
+}
+
 output "lb_subnet_id" {
-  value = openstack_networking_subnet_v2.lb.id
+  value = try(openstack_networking_subnet_v2.lb[0].id, null)
+}
+
+output "agents_subnet_id" {
+  value = openstack_networking_subnet_v2.agents.id
 }
 
 output "restore_cmd" {

--- a/s3.tf
+++ b/s3.tf
@@ -2,16 +2,19 @@ resource "openstack_objectstorage_container_v1" "etcd_snapshots" {
   count = var.ff_native_backup ? 1 : 0
 
   name          = "${var.name}-etcd-snapshots"
+  region        = var.object_store_region
   force_destroy = true
 }
 
 resource "openstack_objectstorage_container_v1" "restic" {
   name          = "${var.name}-restic"
+  region        = var.object_store_region
   force_destroy = true
 }
 
 resource "openstack_objectstorage_container_v1" "velero" {
   name          = "${var.name}-velero"
+  region        = var.object_store_region
   force_destroy = true
 }
 

--- a/secgroup.tf
+++ b/secgroup.tf
@@ -53,45 +53,45 @@ resource "openstack_networking_secgroup_rule_v2" "default" {
   for_each = {
     for rule in [
       # bastion ssh
-      { "port" : 22, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.agent },
-      { "port" : 22, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
+      { "port" : 22, "protocol" : "tcp", "from" : "server", "to" : "agent" },
+      { "port" : 22, "protocol" : "tcp", "from" : "server", "to" : "server" },
       # etcd
-      { "port" : 2379, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 2380, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
+      { "port" : 2379, "protocol" : "tcp", "from" : "server", "to" : "server" },
+      { "port" : 2380, "protocol" : "tcp", "from" : "server", "to" : "server" },
       # api server (k8s)
-      { "port" : 6443, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 6443, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.server },
+      { "port" : 6443, "protocol" : "tcp", "from" : "server", "to" : "server" },
+      { "port" : 6443, "protocol" : "tcp", "from" : "agent", "to" : "server" },
       # rke2 supervisor
-      { "port" : 9345, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 9345, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.server },
+      { "port" : 9345, "protocol" : "tcp", "from" : "server", "to" : "server" },
+      { "port" : 9345, "protocol" : "tcp", "from" : "agent", "to" : "server" },
       # cilium
-      { "port" : 8472, "protocol" : "udp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 8472, "protocol" : "udp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 8472, "protocol" : "udp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.agent },
-      { "port" : 8472, "protocol" : "udp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.agent },
-      { "port" : 4240, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 4240, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 4240, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.agent },
-      { "port" : 4240, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.agent },
-      { "port" : 0, "protocol" : "icmp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 0, "protocol" : "icmp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 0, "protocol" : "icmp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.agent },
-      { "port" : 0, "protocol" : "icmp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.agent },
+      { "port" : 8472, "protocol" : "udp", "from" : "server", "to" : "server" },
+      { "port" : 8472, "protocol" : "udp", "from" : "agent", "to" : "server" },
+      { "port" : 8472, "protocol" : "udp", "from" : "server", "to" : "agent" },
+      { "port" : 8472, "protocol" : "udp", "from" : "agent", "to" : "agent" },
+      { "port" : 4240, "protocol" : "tcp", "from" : "server", "to" : "server" },
+      { "port" : 4240, "protocol" : "tcp", "from" : "agent", "to" : "server" },
+      { "port" : 4240, "protocol" : "tcp", "from" : "server", "to" : "agent" },
+      { "port" : 4240, "protocol" : "tcp", "from" : "agent", "to" : "agent" },
+      { "port" : 0, "protocol" : "icmp", "from" : "server", "to" : "server" },
+      { "port" : 0, "protocol" : "icmp", "from" : "agent", "to" : "server" },
+      { "port" : 0, "protocol" : "icmp", "from" : "server", "to" : "agent" },
+      { "port" : 0, "protocol" : "icmp", "from" : "agent", "to" : "agent" },
       # kubelet
-      { "port" : 10250, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 10250, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.server },
-      { "port" : 10250, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.server, "to" : openstack_networking_secgroup_v2.agent },
-      { "port" : 10250, "protocol" : "tcp", "from" : openstack_networking_secgroup_v2.agent, "to" : openstack_networking_secgroup_v2.agent },
+      { "port" : 10250, "protocol" : "tcp", "from" : "server", "to" : "server" },
+      { "port" : 10250, "protocol" : "tcp", "from" : "agent", "to" : "server" },
+      { "port" : 10250, "protocol" : "tcp", "from" : "server", "to" : "agent" },
+      { "port" : 10250, "protocol" : "tcp", "from" : "agent", "to" : "agent" },
     ] :
-    format("%s->%s-%s-%s", rule.from.name, rule.to.name, rule.protocol, rule.port) => rule
+    format("%s->%s-%s-%s", rule.from, rule.to, rule.protocol, rule.port) => rule
   }
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = each.value.protocol
   port_range_min    = each.value.port
   port_range_max    = each.value.port
-  remote_group_id   = each.value.from.id
-  security_group_id = each.value.to.id
+  remote_ip_prefix  = each.value.from == "server" ? var.subnet_servers_cidr : var.subnet_agents_cidr
+  security_group_id = each.value.to == "server" ? openstack_networking_secgroup_v2.server.id : openstack_networking_secgroup_v2.agent.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "server_server" {
@@ -104,7 +104,7 @@ resource "openstack_networking_secgroup_rule_v2" "server_server" {
   protocol          = each.value.protocol
   port_range_min    = each.value.port
   port_range_max    = each.value.port
-  remote_group_id   = openstack_networking_secgroup_v2.server.id
+  remote_ip_prefix  = var.subnet_servers_cidr
   security_group_id = openstack_networking_secgroup_v2.server.id
 }
 
@@ -118,7 +118,7 @@ resource "openstack_networking_secgroup_rule_v2" "server_agent" {
   protocol          = each.value.protocol
   port_range_min    = each.value.port
   port_range_max    = each.value.port
-  remote_group_id   = openstack_networking_secgroup_v2.server.id
+  remote_ip_prefix  = var.subnet_servers_cidr
   security_group_id = openstack_networking_secgroup_v2.agent.id
 }
 
@@ -132,7 +132,7 @@ resource "openstack_networking_secgroup_rule_v2" "agent_server" {
   protocol          = each.value.protocol
   port_range_min    = each.value.port
   port_range_max    = each.value.port
-  remote_group_id   = openstack_networking_secgroup_v2.agent.id
+  remote_ip_prefix  = var.subnet_agents_cidr
   security_group_id = openstack_networking_secgroup_v2.server.id
 }
 
@@ -146,6 +146,17 @@ resource "openstack_networking_secgroup_rule_v2" "agent_agent" {
   protocol          = each.value.protocol
   port_range_min    = each.value.port
   port_range_max    = each.value.port
-  remote_group_id   = openstack_networking_secgroup_v2.agent.id
+  remote_ip_prefix  = var.subnet_agents_cidr
+  security_group_id = openstack_networking_secgroup_v2.agent.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "legacy_lb_to_agent" {
+  count             = var.ff_lb_subnets_compat ? 1 : 0
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = var.subnet_lb_cidr
   security_group_id = openstack_networking_secgroup_v2.agent.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -99,11 +99,6 @@ variable "cni" {
   default = "cilium"
 }
 
-variable "vip_interface" {
-  type    = string
-  default = "ens3"
-}
-
 variable "dns_nameservers4" {
   type = list(string)
   # Cloudflare
@@ -209,12 +204,14 @@ variable "s3_backup" {
     access_key    = string
     access_secret = string
     bucket        = string
+    region        = optional(string)
   })
   default = {
     endpoint      = ""
     access_key    = ""
     access_secret = ""
     bucket        = ""
+    region        = null
   }
 }
 
@@ -318,6 +315,11 @@ variable "object_store_endpoint" {
   default = ""
 }
 
+variable "object_store_region" {
+  type    = string
+  default = null
+}
+
 variable "identity_endpoint" {
   type = string
 }
@@ -325,6 +327,12 @@ variable "identity_endpoint" {
 variable "ff_write_kubeconfig" {
   type    = bool
   default = true
+}
+
+variable "ff_lb_subnets_compat" {
+  type        = bool
+  default     = false
+  description = "Enable backward compatibility for existing Load Balancers in the legacy LB subnet"
 }
 
 variable "ff_autoremove_agent" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,18 +1,18 @@
 terraform {
-  required_version = ">= 1.3.3"
+  required_version = ">= 1.6"
 
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.6.0"
+      version = ">= 3"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2.2"
+      version = ">= 3"
     }
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "~> 2.1.0"
+      version = ">= 3"
     }
   }
 }


### PR DESCRIPTION
- Provider & Terraform upgrade: Bumped minimum Terraform version to >= 1.6 and OpenStack provider to >= 3.
- Subnet consolidation (L2 routing): Load Balancers are now provisioned directly in the agents subnet instead of their own dedicated subnet. This bypasses the OpenStack L3 router (OVN), definitively solving MTU/fragmentation drops on heavy VXLAN traffic.
- Note: A new ff_lb_subnets_compat feature flag has been added (defaults to false) to maintain the legacy LB subnet and security rules for existing deployments during migration.
- Immutable Security Groups: Replaced OpenStack dynamic remote_group_id with static CIDR rules (remote_ip_prefix) to prevent firewall lockouts when OpenStack networking agents fail to synchronize.
- Auto-detect VIP Interface: Removed the vip_interface variable. kube-vip now automatically detects the default gateway interface, natively solving issues where underlying hardware upgrades silently rename network interfaces (e.g., ens3 to enp3s0).
- Ingress Controllers: Disabled rke2-traefik by default alongside rke2-ingress-nginx.
- S3 Region Support: Added object_store_region variable and integrated it into etcd backup configurations to support S3 providers requiring explicit region definitions.
- Cloud Providers Upgrade: Bumped openstack-cloud-controller-manager and openstack-cinder-csi Helm charts to version 2.36.0.
- Robust Disk Mounting: The RKE2 data volume is now mounted using /dev/disk/by-label/rke2_data instead of the raw device path to prevent mount failures if device order changes.