### PR TITLE
feat: test RKE2 chart patches and fix cloud-init bootstrap failures

### DIFF
--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -1,0 +1,39 @@
+name: patches
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  patches:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install yq
+        run: |
+          wget -q https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64.tar.gz -O - | tar xz
+          sudo mv yq_linux_amd64 /usr/local/bin/yq
+          yq --version
+
+      - name: Run patch tests
+        env:
+          YQ_BIN: /usr/local/bin/yq
+        run: |
+          uv sync
+          uv run pytest -q
+
+      - name: Upload diff on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshots-diff
+          path: tests/patches/snapshots/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.tfstate.*
 crash.log
 *.tfvars
-rke2.yaml
 .terraform.lock.hcl
 *.rke2.yaml
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/RKE2.yaml
+++ b/RKE2.yaml
@@ -1,0 +1,3 @@
+versions:
+  - "v1.35.6+rke2r1"
+  - "v1.36.2+rke2r1"

--- a/node/cloud-init.yaml.tpl
+++ b/node/cloud-init.yaml.tpl
@@ -84,8 +84,33 @@ write_files:
     export INSTALL_RKE2_VERSION=${rke2_version}
     which rke2 >/dev/null 2>&1 && RKE2_VERSION=$(rke2 --version | head -1 | cut -f 3 -d " ")
     if ([ -z "$RKE2_VERSION" ]) || ([ -n "$INSTALL_RKE2_VERSION" ] && [ "$INSTALL_RKE2_VERSION" != "$RKE2_VERSION" ]); then
-      curl -sfL https://get.rke2.io | sh - || { echo "Failed to download or install rke2"; exit 1; }
+      curl -sfL https://get.rke2.io -o /tmp/rke2-install.sh && sh /tmp/rke2-install.sh || { echo "Failed to download or install rke2"; exit 1; }
     fi
+- path: /usr/local/bin/cloud-init-wait.sh
+  permissions: "0755"
+  owner: root:root
+  content: |
+    #!/bin/bash
+    wait_for() {
+      _wf_desc="$1"; _wf_test="$2"; _wf_sleep="$3"; _wf_max="$4"; _wf_n=0
+      until eval "$_wf_test"; do
+        _wf_n=$((_wf_n + 1))
+        if [ "$_wf_n" -ge "$_wf_max" ]; then
+          echo "FATAL: $_wf_desc not ready after $_wf_max attempts on $(hostname) - node unusable, aborting cloud-init"
+          exit 1
+        fi
+        echo "Waiting for $(hostname): $_wf_desc ($_wf_n/$_wf_max)"
+        sleep "$_wf_sleep"
+      done
+    }
+    _charts_ready() {
+      _cr_miss=""
+      for _cr_p in /opt/rke2/manifests/patches/*; do
+        [ -e "$_cr_p" ] || continue
+        [ -f "/var/lib/rancher/rke2/server/manifests/$(basename "$_cr_p")" ] || _cr_miss=1
+      done
+      [ -z "$_cr_miss" ]
+    }
 %{ if is_server ~}
   %{~ for k, v in manifests_files ~}
 - path: /opt/rke2/manifests/${k}
@@ -97,37 +122,13 @@ write_files:
 - path: /usr/local/bin/customize-chart.sh
   permissions: "0755"
   owner: root:root
-  content: |
-    #!/bin/bash
-    CHART_FILE=$1
-    CHART_NAME=$(basename $CHART_FILE .yaml)
-    DELTA=$2
-    TAR_FILE=chart.tar
-    FILE=values.yaml
-    TAR_OPTS="--owner=0 --group=0 --mode=gou-s+r --numeric-owner --no-acls --no-selinux --no-xattrs"
-    echo "Customizing $CHART_FILE with $DELTA"
-    cat $CHART_FILE | yq -r .spec.chartContent | base64 -d | gunzip - > $TAR_FILE
-    tar -xOf $TAR_FILE $CHART_NAME/$FILE > $FILE
-    yq -i e '. *= load("'$DELTA'")' $FILE
-    tar --delete -b 8192 -f $TAR_FILE $CHART_NAME/$FILE
-    tar --transform="s|.*|$CHART_NAME/$FILE|" $TAR_OPTS -vrf $TAR_FILE $FILE
-    gzip -9 $TAR_FILE
-    cat $TAR_FILE.gz | base64 -w 0 > $TAR_FILE.gz.b64
-    yq -i e '.spec.chartContent = load_str("'$TAR_FILE'.gz.b64")' $CHART_FILE
-    rm $TAR_FILE.gz $TAR_FILE.gz.b64 $FILE
+  encoding: gz+b64
+  content: ${customize_chart_script}
 - path: /usr/local/bin/customize-charts.sh
   permissions: "0755"
   owner: root:root
-  content: |
-    #!/bin/bash
-    CHARTS_DIR=$1
-    ls $CHARTS_DIR
-    for patch in /opt/rke2/manifests/patches/*; do
-      patch_name=$(basename "$patch")
-      if [ -f "$CHARTS_DIR/$patch_name" ] && [ "$(yq e 'length' "$CHARTS_DIR/$patch_name")" -ne "0" ]; then
-        /usr/local/bin/customize-chart.sh "$CHARTS_DIR/$patch_name" "$patch"
-      fi
-    done
+  encoding: gz+b64
+  content: ${customize_charts_script}
 - path: /etc/modules-load.d/ipvs.conf
   permissions: "0644"
   owner: root:root
@@ -239,10 +240,10 @@ write_files:
     etcd-s3-region: "${s3.region}"
     %{~ endif ~}
       %{~ if backup_schedule != null ~}
-    etcd-snapshot-schedule-cron: ${backup_schedule}
+    etcd-snapshot-schedule-cron: "${backup_schedule}"
       %{~ endif ~}
       %{~ if backup_retention != null ~}
-    etcd-snapshot-retention: ${backup_retention}
+    etcd-snapshot-retention: "${backup_retention}"
       %{~ endif ~}
     etcd-snapshot-compress: true
     %{~ endif ~}
@@ -278,7 +279,7 @@ write_files:
   content: |
     token: "${rke2_token}"
     server: https://${internal_vip}:9345
-    node-ip: ${node_ip}
+    node-ip: "${node_ip}"
     cloud-provider-name: external
     %{~ if length(node_taints) > 0 ~}
     node-taint:
@@ -310,44 +311,42 @@ runcmd:
   - systemctl enable mnt.mount var-lib-rancher-rke2.mount var-lib-kubelet.mount
   - systemctl start mnt.mount var-lib-rancher-rke2.mount var-lib-kubelet.mount
   %{~ for key in authorized_keys ~}
-  - echo "${key}" >> /home/${system_user}/.ssh/authorized_keys
+  - grep -qxF "${key}" /home/${system_user}/.ssh/authorized_keys || echo "${key}" >> /home/${system_user}/.ssh/authorized_keys
   %{~ endfor ~}
   - /usr/local/bin/install-or-upgrade-rke2.sh
-  - echo 'alias crictl="sudo /var/lib/rancher/rke2/bin/crictl -r unix:///run/k3s/containerd/containerd.sock"' >> /home/${system_user}/.bashrc
-  - echo 'alias ctr="sudo /var/lib/rancher/rke2/bin/ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io"' >> /home/${system_user}/.bashrc
-  - >
-    for MNT in /mnt; do
-      RETRIES=0; MAX_RETRIES=30;
-      until mountpoint -q "$MNT"; do
-        RETRIES=$((RETRIES + 1));
-        if [ $RETRIES -ge $MAX_RETRIES ]; then
-          echo "ERROR: $MNT not mounted after $MAX_RETRIES retries.";
-          exit 1;
-        fi;
-        echo "$MNT not mounted yet, retrying in 10 seconds...";
-        sleep 5;
-      done;
-      echo "$MNT mounted successfully.";
-    done;
+  - systemctl daemon-reload
+  - grep -qxF 'alias crictl="sudo /var/lib/rancher/rke2/bin/crictl -r unix:///run/k3s/containerd/containerd.sock"' /home/${system_user}/.bashrc || echo 'alias crictl="sudo /var/lib/rancher/rke2/bin/crictl -r unix:///run/k3s/containerd/containerd.sock"' >> /home/${system_user}/.bashrc
+  - grep -qxF 'alias ctr="sudo /var/lib/rancher/rke2/bin/ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io"' /home/${system_user}/.bashrc || echo 'alias ctr="sudo /var/lib/rancher/rke2/bin/ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io"' >> /home/${system_user}/.bashrc
+  - bash -c 'source /usr/local/bin/cloud-init-wait.sh && wait_for "/mnt mountpoint" "mountpoint -q /mnt" 5 30'
   %{~ if is_server ~}
   - systemctl restart systemd-modules-load.service # ensure ipvs is loaded
-  - echo 'alias kubectl="sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml"' >> /home/${system_user}/.bashrc
-  - rm -rf /var/lib/rancher/rke2/server/manifests # single-node cleanup
+  - grep -qxF 'alias kubectl="sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml"' /home/${system_user}/.bashrc || echo 'alias kubectl="sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml"' >> /home/${system_user}/.bashrc
+  - if ! systemctl is-active -q rke2-server.service; then rm -rf /var/lib/rancher/rke2/server/manifests; fi # clear stale manifests only on a fresh/inactive node
+  - >
+    YQ_SHA256="bccbf5ce1717ea5cec9662446b8bfa5863747ffb0a49a32e4c8dd23ada5c26fa";
+    for i in $(seq 1 10); do
+      wget -T 30 https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64.tar.gz -O /tmp/yq_linux_amd64.tar.gz && echo "$YQ_SHA256  /tmp/yq_linux_amd64.tar.gz" | sha256sum -c - && tar xzf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq && break;
+      sleep 5;
+    done;
+    rm -f /tmp/yq_linux_amd64.tar.gz;
+    command -v yq >/dev/null || { echo "ERROR: yq install/checksum failed"; exit 1; };
   - systemctl enable rke2-server.service
   - systemctl start rke2-server.service
-  - until [ -d /var/lib/rancher/rke2/agent/pod-manifests/ ]; do echo "Waiting for $(hostname) static pods"; sleep 1; done
+  - bash -c 'source /usr/local/bin/cloud-init-wait.sh && wait_for "chart manifests" _charts_ready 1 60'
+  - /usr/local/bin/customize-charts.sh /var/lib/rancher/rke2/server/manifests
+  - >
+    for f in /opt/rke2/manifests/*.yaml; do [ -e "$f" ] || continue; mv -v "$f" /var/lib/rancher/rke2/server/manifests; done;
+  - ls /var/lib/rancher/rke2/server/manifests
+  - bash -c 'source /usr/local/bin/cloud-init-wait.sh && wait_for "static pod manifests dir" "[ -d /var/lib/rancher/rke2/agent/pod-manifests/ ]" 1 60'
   - mv -v /opt/rke2/kube-vip.yaml /var/lib/rancher/rke2/agent/pod-manifests/kube-vip.yaml
   - ls /var/lib/rancher/rke2/agent/pod-manifests
-  - wget https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64.tar.gz -O - | tar xz && mv yq_linux_amd64 /usr/bin/yq
-  - until [ -d /var/lib/rancher/rke2/data/v*/charts ]; do echo "Waiting for $(hostname) charts data"; sleep 1; done
-  - /usr/local/bin/customize-charts.sh $(realpath /var/lib/rancher/rke2/data/v*/charts)
-  - until [ -d /var/lib/rancher/rke2/server/manifests ]; do echo "Waiting for $(hostname) manifests"; sleep 1; done
-  - /usr/local/bin/customize-charts.sh /var/lib/rancher/rke2/server/manifests
-  - mv -v /opt/rke2/manifests/*.yaml /var/lib/rancher/rke2/server/manifests
-  - ls /var/lib/rancher/rke2/server/manifests
-  - until systemctl is-active -q rke2-server.service; do echo "Waiting for $(hostname) rke2 to start"; sleep 3; journalctl -u rke2-server.service --since "3 second ago"; done
+  - bash -c 'source /usr/local/bin/cloud-init-wait.sh && wait_for "rke2-server active" "systemctl is-active -q rke2-server.service" 3 60'
+  %{~ if bootstrap ~}
+  - systemctl restart rke2-server.service # force deploy controller to re-read patched server/manifests (bootstrap only)
+  - bash -c 'source /usr/local/bin/cloud-init-wait.sh && wait_for "rke2-server active after restart" "systemctl is-active -q rke2-server.service" 3 60'
+  %{~ endif ~}
   %{~ else ~}
   - systemctl enable rke2-agent.service
   - systemctl start rke2-agent.service
-  - until systemctl is-active -q rke2-agent.service; do echo "Waiting for $(hostname) rke2 to start"; sleep 3; journalctl -u rke2-agent.service --since "3 second ago"; done
+  - bash -c 'source /usr/local/bin/cloud-init-wait.sh && wait_for "rke2-agent active" "systemctl is-active -q rke2-agent.service" 3 60'
   %{~ endif ~}

--- a/node/customize-chart.sh
+++ b/node/customize-chart.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+CHART_FILE="$1"
+DELTA="$2"
+CHART_NAME="$(basename "$CHART_FILE")"
+CHART_NAME="${CHART_NAME%.*}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+TAR_FILE="$WORK/chart.tar"
+TAR_OPTS="--owner=0 --group=0 --mode=gou-s+r --numeric-owner --no-acls --no-selinux --no-xattrs"
+FILE="$WORK/values.yaml"
+echo "Customizing $CHART_FILE with $DELTA"
+yq -r .spec.chartContent "$CHART_FILE" | base64 -d | gunzip - > "$TAR_FILE"
+tar -xOf "$TAR_FILE" "$CHART_NAME/values.yaml" > "$FILE"
+yq -i e '. *= load("'$DELTA'")' "$FILE"
+tar --delete -b 8192 -f "$TAR_FILE" "$CHART_NAME/values.yaml"
+tar --transform="s|.*|$CHART_NAME/values.yaml|" $TAR_OPTS -vrf "$TAR_FILE" "$FILE"
+gzip -9 -c "$TAR_FILE" | base64 -w 0 > "$TAR_FILE.b64"
+yq -i e '.spec.chartContent = load_str("'$TAR_FILE'.b64")' "$CHART_FILE"

--- a/node/customize-charts.sh
+++ b/node/customize-charts.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s nullglob
+CHARTS_DIR="$1"
+PATCHES_DIR="${2:-/opt/rke2/manifests/patches}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+[ -d "$PATCHES_DIR" ] || { echo "no patches dir $PATCHES_DIR"; exit 0; }
+ls "$CHARTS_DIR"
+matched=0
+for patch in "$PATCHES_DIR"/*; do
+  patch_name="$(basename "$patch")"
+  chart="$CHARTS_DIR/$patch_name"
+  [ -f "$chart" ] || continue
+  len="$(yq e 'length' "$chart")" || { echo "yq failed on $chart" >&2; exit 1; }
+  [ "$len" != "0" ] || continue
+  "$SCRIPT_DIR/customize-chart.sh" "$chart" "$patch"
+  matched=$((matched + 1))
+done
+[ "$matched" -gt 0 ] || echo "warning: no patches applied to $CHARTS_DIR"

--- a/node/main.tf
+++ b/node/main.tf
@@ -124,13 +124,15 @@ resource "openstack_compute_instance_v2" "instance" {
       try("kube-proxy-cpu=${var.kube_proxy_resources.limits.cpu}", ""),
       try("kube-proxy-memory=${var.kube_proxy_resources.limits.memory}", ""),
     ] : limit if limit != ""])
-    system_user       = var.system_user
-    authorized_keys   = var.ssh_authorized_keys
-    ff_wait_apiserver = false
-    ff_with_kubeproxy = var.ff_with_kubeproxy
-    node_taints       = [for t in var.node_taints : "${t.key}${t.value != null ? "=${t.value}" : ""}:${t.effect}"]
-    node_labels       = var.node_labels
-    registries        = var.registries
+    system_user             = var.system_user
+    customize_chart_script  = base64gzip(file("${path.module}/customize-chart.sh"))
+    customize_charts_script = base64gzip(file("${path.module}/customize-charts.sh"))
+    authorized_keys         = var.ssh_authorized_keys
+    ff_wait_apiserver       = false
+    ff_with_kubeproxy       = var.ff_with_kubeproxy
+    node_taints             = [for t in var.node_taints : "${t.key}${t.value != null ? "=${t.value}" : ""}:${t.effect}"]
+    node_labels             = var.node_labels
+    registries              = var.registries
   }))
 }
 

--- a/patches/rke2-cilium.yaml.tpl
+++ b/patches/rke2-cilium.yaml.tpl
@@ -2,7 +2,7 @@ cluster:
   name: ${cluster_name}
   id: ${cluster_id}
 enableIPv4Masquerade: true
-kubeProxyReplacement: "${ff_with_kubeproxy ? false : true}"
+kubeProxyReplacement: ${ff_with_kubeproxy ? "false" : "true"}
 k8sServiceHost: 127.0.0.1
 k8sServicePort: 6443
 operator:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "terraform-openstack-rke2"
+version = "0.0.0"
+requires-python = ">=3.9"
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.uv]
+package = false
+default-groups = ["dev"]
+required-version = ">=0.11"
+
+[tool.pytest.ini_options]
+testpaths = ["tests/patches"]

--- a/tests/patches/conftest.py
+++ b/tests/patches/conftest.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+
+from helpers import load_rke2_versions, render_patches, run
+
+
+@pytest.fixture(scope="session")
+def rendered_patches(tmp_path_factory) -> dict:
+    out = tmp_path_factory.mktemp("rendered-patches")
+    patches = {}
+    for chart, content in render_patches().items():
+        path = out / chart
+        path.write_text(content)
+        patches[chart.removesuffix(".yaml")] = path
+    return patches
+
+
+@pytest.fixture(scope="session")
+def charts_cache(tmp_path_factory) -> dict:
+    cache = {}
+    versions = load_rke2_versions()
+    only = os.environ.get("RKE2_VERSION")
+    if only:
+        versions = [v for v in versions if v == only]
+    for version in versions:
+        tag = version.replace("+", "-")
+        dest = tmp_path_factory.mktemp(f"charts-{tag}")
+        name = f"rt-{tag}"
+        run(["docker", "rm", "-f", name], check=False)
+        run(["docker", "create", "--entrypoint", "/bin/sh", "--name", name, f"rancher/rke2-runtime:{tag}"])
+        run(["docker", "cp", f"{name}:/charts", str(dest)])
+        run(["docker", "rm", name])
+        cache[version] = dest / "charts"
+    return cache
+
+
+def pytest_generate_tests(metafunc):
+    if "version" in metafunc.fixturenames:
+        versions = load_rke2_versions()
+        only = os.environ.get("RKE2_VERSION")
+        if only:
+            versions = [v for v in versions if v == only]
+        metafunc.parametrize("version", versions)

--- a/tests/patches/helpers.py
+++ b/tests/patches/helpers.py
@@ -1,0 +1,153 @@
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import tarfile
+import difflib
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+PATCHES_DIR = ROOT / "patches"
+RKE2_YAML = ROOT / "RKE2.yaml"
+SNAPSHOTS_DIR = Path(__file__).resolve().parent / "snapshots"
+YQ_VERSION = "4.40.5"
+
+# Stable render fixtures for patches/rke2-*.yaml.tpl; prod binds the same vars in main.tf (cilium ~L109, coredns ~L118). Every fixture value is a typed placeholder token (<value:int|string|bool>) so every value that appears in the snapshot diff is obviously a voluntary test value, never a real prod default.
+PATCH_VARS = {
+    "operator_replica": "<value:int>",
+    "cluster_name": "<value:string>",
+    "cluster_id": "<value:int>",
+    "ff_with_kubeproxy": "<value:bool>",
+    "enable_encryption": "<value:bool>",
+    "encryption_type": "<value:string>",
+    "enable_node_encryption": "<value:bool>",
+}
+
+
+def version_tag(version: str) -> str:
+    return version.replace("+", "-")
+
+
+def load_rke2_versions():
+    with RKE2_YAML.open() as f:
+        data = yaml.safe_load(f)
+    versions = data.get("versions", [])
+    if not versions:
+        raise ValueError(f"No versions found in {RKE2_YAML}")
+    return versions
+
+
+def run(cmd: list, *, cwd: Optional[Path] = None, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, check=check, capture_output=True, text=True)
+
+
+def yq_bin() -> str:
+    path = os.environ.get("YQ_BIN")
+    if path and Path(path).is_file():
+        return path
+    found = shutil.which("yq")
+    if found:
+        return found
+    raise RuntimeError("yq not found; install mikefarah/yq v4.40.5 or set YQ_BIN")
+
+
+def render_patch_tpl(tpl_path: Path) -> str:
+    content = tpl_path.read_text()
+
+    def replace_ternary(match: re.Match) -> str:
+        var = match.group(1).strip()
+        false_val = match.group(2).strip()
+        true_val = match.group(3).strip()
+        val = PATCH_VARS[var]
+        if isinstance(val, str):
+            return val
+        return false_val if val else true_val
+
+    content = re.sub(
+        r"\$\{(\w+)\s*\?\s*([^:]+)\s*:\s*([^}]+)\}",
+        replace_ternary,
+        content,
+    )
+    for key, value in PATCH_VARS.items():
+        if isinstance(value, bool):
+            rendered = "true" if value else "false"
+        else:
+            rendered = str(value)
+        content = content.replace(f"${{{key}}}", rendered)
+    return content
+
+
+def render_patches() -> Dict[str, str]:
+    patches = {}
+    for tpl_path in sorted(PATCHES_DIR.glob("rke2-*.yaml.tpl")):
+        chart = tpl_path.name.removesuffix(".tpl")
+        patches[chart] = render_patch_tpl(tpl_path)
+    if not patches:
+        raise RuntimeError(f"No patch templates found in {PATCHES_DIR}")
+    return patches
+
+
+def patch_top_level_keys(patch_path: Path) -> List[str]:
+    data = yaml.safe_load(patch_path.read_text())
+    if not isinstance(data, dict):
+        return []
+    return list(data.keys())
+
+
+def pick_expr(keys: List[str]) -> str:
+    inner = ", ".join(f'"{key}": .["{key}"]' for key in keys)
+    return "{" + inner + "}"
+
+
+def extract_patch_subset(values_path: Path, keys: List[str]) -> str:
+    if not keys:
+        return "{}\n"
+    return run([yq_bin(), "-o=yaml", pick_expr(keys), str(values_path)]).stdout
+
+
+def patch_keys_diff(
+    values_path: Path,
+    patched_path: Path,
+    patch_path: Path,
+    chart: str,
+) -> str:
+    keys = patch_top_level_keys(patch_path)
+    original = extract_patch_subset(values_path, keys)
+    patched = extract_patch_subset(patched_path, keys)
+    if original == patched:
+        return ""
+    return "".join(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            patched.splitlines(keepends=True),
+            fromfile=f"{chart}/values.yaml",
+            tofile=f"{chart}/values.patched.yaml",
+        )
+    )
+
+
+def extract_chart_values(chart_file: Path, chart_name: str, workdir: Path) -> Tuple[Path, str]:
+    tar_path = workdir / "chart.tar"
+    values_path = workdir / "values.yaml"
+    chart_content = run([yq_bin(), "-r", ".spec.chartContent", str(chart_file)]).stdout
+    tar_path.write_bytes(__import__("base64").b64decode(chart_content))
+    with tarfile.open(tar_path, "r:gz") as tar:
+        values_path.write_bytes(tar.extractfile(f"{chart_name}/values.yaml").read())
+    chart_yaml_path = workdir / "Chart.yaml"
+    with tarfile.open(tar_path, "r:gz") as tar:
+        chart_yaml_path.write_bytes(tar.extractfile(f"{chart_name}/Chart.yaml").read())
+    chart_version = run([yq_bin(), "-r", ".version", str(chart_yaml_path)]).stdout.strip()
+    return values_path, chart_version
+
+
+def merge_patch(values_path: Path, patch_path: Path, output_path: Path) -> None:
+    shutil.copy(values_path, output_path)
+    run([yq_bin(), "-i", "e", f'. *= load("{patch_path}")', str(output_path)])
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/tests/patches/snapshots/v1.35.6-rke2r1/meta.json
+++ b/tests/patches/snapshots/v1.35.6-rke2r1/meta.json
@@ -1,0 +1,15 @@
+{
+  "rke2_version": "v1.35.6+rke2r1",
+  "charts": {
+    "rke2-cilium": {
+      "chart_version": "1.19.402",
+      "values_sha256": "8cc5ea128f81c620af4e8fe4561b7c3b8d765a44dda628290519efebbf9a27c1",
+      "merge_status": "ok"
+    },
+    "rke2-coredns": {
+      "chart_version": "1.46.002",
+      "values_sha256": "3f38e09c5f78f4820a88076d26c9920e9ebd99d40a92e454eb5d3811af48e44e",
+      "merge_status": "ok"
+    }
+  }
+}

--- a/tests/patches/snapshots/v1.35.6-rke2r1/rke2-cilium.patch
+++ b/tests/patches/snapshots/v1.35.6-rke2r1/rke2-cilium.patch
@@ -1,0 +1,139 @@
+--- rke2-cilium/values.yaml
++++ rke2-cilium/values.patched.yaml
+@@ -5,15 +5,15 @@
+   # * It must begin and end with a lower case alphanumeric character;
+   # * It may contain lower case alphanumeric characters and dashes between.
+   # The "default" name cannot be used if the Cluster ID is different from 0.
+-  name: default
++  name: <value:string>
+   # -- (int) Unique ID of the cluster. Must be unique across all connected
+   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
+   # may be 0 if Cluster Mesh is not used.
+-  id: 0
+-enableIPv4Masquerade: ~
+-kubeProxyReplacement: "false"
+-k8sServiceHost: ""
+-k8sServicePort: ""
++  id: <value:int>
++enableIPv4Masquerade: true
++kubeProxyReplacement: "<value:bool>"
++k8sServiceHost: "127.0.0.1"
++k8sServicePort: 6443
+ operator:
+   # -- Enable the cilium-operator component (required).
+   enabled: true
+@@ -31,7 +31,7 @@
+     pullPolicy: "IfNotPresent"
+     suffix: ""
+   # -- Number of replicas to run for the cilium-operator deployment
+-  replicas: 2
++  replicas: <value:int>
+   # -- The priority class to use for cilium-operator
+   priorityClassName: ""
+   # -- DNS policy for Cilium operator pods.
+@@ -67,6 +67,7 @@
+   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+   nodeSelector:
+     kubernetes.io/os: linux
++    node-role.kubernetes.io/control-plane: "true"
+   # -- Node tolerations for cilium-operator scheduling to nodes with taints
+   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+   # Toleration for agentNotReadyTaintKey taint is always added to cilium-operator pods.
+@@ -136,7 +137,12 @@
+     unhealthyPodEvictionPolicy: null
+   # -- cilium-operator resource limits & requests
+   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+-  resources: {}
++  resources:
++    requests:
++      cpu: 50m
++      memory: 256Mi
++    limits:
++      memory: 384Mi
+   #   limits:
+   #     cpu: 1000m
+   #     memory: 1Gi
+@@ -272,7 +278,7 @@
+   #  - portmap
+
+   # Otherwise rke2 hostPort does not work! Used for nginx
+-  chainingMode: portmap
++  chainingMode: "none"
+   # @schema
+   # type: [null, string]
+   # @schema
+@@ -339,10 +345,15 @@
+   enableRouteMTUForCNIChaining: false
+   # -- Enable the removal of iptables rules created by the AWS CNI VPC plugin.
+   iptablesRemoveAWSRules: true
+-resources: {}
++resources:
++  requests:
++    cpu: 50m
++    memory: 256Mi
++  limits:
++    memory: 512Mi
+ hubble:
+   # -- Enable Hubble (true by default).
+-  enabled: false
++  enabled: true
+   # -- Annotations to be added to all top-level hubble objects (resources under templates/hubble)
+   annotations: {}
+   # -- Buffer size of the channel Hubble uses to receive monitor events. If this
+@@ -381,7 +392,16 @@
+     #
+     #   --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
+     #
+-    enabled: ~
++    enabled:
++      - dns
++      - drop
++      - flow
++      - flows-to-world
++      - httpV2
++      - icmp
++      - kafka
++      - port-distribution
++      - tcp
+     # -- Enables exporting hubble metrics in OpenMetrics format.
+     enableOpenMetrics: false
+     # -- Configure the port the hubble metric server listens on.
+@@ -641,7 +661,7 @@
+       extraIpAddresses: []
+   relay:
+     # -- Enable Hubble Relay (requires hubble.enabled=true)
+-    enabled: false
++    enabled: true
+     # -- Roll out Hubble Relay pods automatically when configmap is updated.
+     rollOutPods: false
+     # -- Hubble-relay container image.
+@@ -655,7 +675,12 @@
+       useDigest: false
+       pullPolicy: "IfNotPresent"
+     # -- Specifies the resources for the hubble-relay pods
+-    resources: {}
++    resources:
++      requests:
++        cpu: 25m
++        memory: 128Mi
++      limits:
++        memory: 128Mi
+     # -- Number of replicas run for the hubble-relay deployment.
+     replicas: 1
+     # -- Affinity for hubble-replay
+@@ -1157,12 +1182,12 @@
+       - policy_denied
+ encryption:
+   # -- Enable transparent network encryption.
+-  enabled: false
++  enabled: <value:bool>
+   # -- Encryption method. Can be one of ipsec, wireguard or ztunnel.
+-  type: ipsec
++  type: <value:string>
+   # -- Enable encryption for pure node to node traffic.
+   # This option is only effective when encryption.type is set to "wireguard".
+-  nodeEncryption: false
++  nodeEncryption: <value:bool>
+   # -- Configure the Encryption Pod2Pod strict mode.
+   strictMode:
+     # -- Enable Encryption Pod2Pod strict mode. (deprecated: please use encryption.strictMode.egress.enabled)

--- a/tests/patches/snapshots/v1.35.6-rke2r1/rke2-coredns.patch
+++ b/tests/patches/snapshots/v1.35.6-rke2r1/rke2-coredns.patch
@@ -1,0 +1,41 @@
+--- rke2-coredns/values.yaml
++++ rke2-coredns/values.patched.yaml
+@@ -1,10 +1,10 @@
+ resources:
+   limits:
+-    cpu: 100m
+-    memory: 128Mi
++    cpu: "100m" # because of autoscaler
++    memory: "128Mi"
+   requests:
+-    cpu: 100m
+-    memory: 128Mi
++    cpu: "100m"
++    memory: "128Mi"
+ autoscaler:
+   # Enabled the cluster-proportional-autoscaler
+   enabled: true
+@@ -13,7 +13,7 @@
+   # Number of nodes in the cluster per coredns replica
+   nodesPerReplica: 16
+   # Min size of replicaCount
+-  min: 0
++  min: <value:int>
+   # Max size of replicaCount (default of 0 is no max)
+   max: 0
+   # Whether to include unschedulable nodes in the nodes/cores calculations - this requires version 1.8.0+ of the autoscaler
+@@ -56,11 +56,11 @@
+   # resources for autoscaler pod
+   resources:
+     requests:
+-      cpu: "25m"
+-      memory: "16Mi"
++      cpu: "20m"
++      memory: "10Mi"
+     limits:
+       cpu: "100m"
+-      memory: "64Mi"
++      memory: "10Mi"
+   # Options for autoscaler configmap
+   configmap:
+     ## Annotations for the coredns-autoscaler configmap

--- a/tests/patches/snapshots/v1.36.2-rke2r1/meta.json
+++ b/tests/patches/snapshots/v1.36.2-rke2r1/meta.json
@@ -1,0 +1,15 @@
+{
+  "rke2_version": "v1.36.2+rke2r1",
+  "charts": {
+    "rke2-cilium": {
+      "chart_version": "1.19.402",
+      "values_sha256": "8cc5ea128f81c620af4e8fe4561b7c3b8d765a44dda628290519efebbf9a27c1",
+      "merge_status": "ok"
+    },
+    "rke2-coredns": {
+      "chart_version": "1.46.002",
+      "values_sha256": "3f38e09c5f78f4820a88076d26c9920e9ebd99d40a92e454eb5d3811af48e44e",
+      "merge_status": "ok"
+    }
+  }
+}

--- a/tests/patches/snapshots/v1.36.2-rke2r1/rke2-cilium.patch
+++ b/tests/patches/snapshots/v1.36.2-rke2r1/rke2-cilium.patch
@@ -1,0 +1,139 @@
+--- rke2-cilium/values.yaml
++++ rke2-cilium/values.patched.yaml
+@@ -5,15 +5,15 @@
+   # * It must begin and end with a lower case alphanumeric character;
+   # * It may contain lower case alphanumeric characters and dashes between.
+   # The "default" name cannot be used if the Cluster ID is different from 0.
+-  name: default
++  name: <value:string>
+   # -- (int) Unique ID of the cluster. Must be unique across all connected
+   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
+   # may be 0 if Cluster Mesh is not used.
+-  id: 0
+-enableIPv4Masquerade: ~
+-kubeProxyReplacement: "false"
+-k8sServiceHost: ""
+-k8sServicePort: ""
++  id: <value:int>
++enableIPv4Masquerade: true
++kubeProxyReplacement: "<value:bool>"
++k8sServiceHost: "127.0.0.1"
++k8sServicePort: 6443
+ operator:
+   # -- Enable the cilium-operator component (required).
+   enabled: true
+@@ -31,7 +31,7 @@
+     pullPolicy: "IfNotPresent"
+     suffix: ""
+   # -- Number of replicas to run for the cilium-operator deployment
+-  replicas: 2
++  replicas: <value:int>
+   # -- The priority class to use for cilium-operator
+   priorityClassName: ""
+   # -- DNS policy for Cilium operator pods.
+@@ -67,6 +67,7 @@
+   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+   nodeSelector:
+     kubernetes.io/os: linux
++    node-role.kubernetes.io/control-plane: "true"
+   # -- Node tolerations for cilium-operator scheduling to nodes with taints
+   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+   # Toleration for agentNotReadyTaintKey taint is always added to cilium-operator pods.
+@@ -136,7 +137,12 @@
+     unhealthyPodEvictionPolicy: null
+   # -- cilium-operator resource limits & requests
+   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+-  resources: {}
++  resources:
++    requests:
++      cpu: 50m
++      memory: 256Mi
++    limits:
++      memory: 384Mi
+   #   limits:
+   #     cpu: 1000m
+   #     memory: 1Gi
+@@ -272,7 +278,7 @@
+   #  - portmap
+
+   # Otherwise rke2 hostPort does not work! Used for nginx
+-  chainingMode: portmap
++  chainingMode: "none"
+   # @schema
+   # type: [null, string]
+   # @schema
+@@ -339,10 +345,15 @@
+   enableRouteMTUForCNIChaining: false
+   # -- Enable the removal of iptables rules created by the AWS CNI VPC plugin.
+   iptablesRemoveAWSRules: true
+-resources: {}
++resources:
++  requests:
++    cpu: 50m
++    memory: 256Mi
++  limits:
++    memory: 512Mi
+ hubble:
+   # -- Enable Hubble (true by default).
+-  enabled: false
++  enabled: true
+   # -- Annotations to be added to all top-level hubble objects (resources under templates/hubble)
+   annotations: {}
+   # -- Buffer size of the channel Hubble uses to receive monitor events. If this
+@@ -381,7 +392,16 @@
+     #
+     #   --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
+     #
+-    enabled: ~
++    enabled:
++      - dns
++      - drop
++      - flow
++      - flows-to-world
++      - httpV2
++      - icmp
++      - kafka
++      - port-distribution
++      - tcp
+     # -- Enables exporting hubble metrics in OpenMetrics format.
+     enableOpenMetrics: false
+     # -- Configure the port the hubble metric server listens on.
+@@ -641,7 +661,7 @@
+       extraIpAddresses: []
+   relay:
+     # -- Enable Hubble Relay (requires hubble.enabled=true)
+-    enabled: false
++    enabled: true
+     # -- Roll out Hubble Relay pods automatically when configmap is updated.
+     rollOutPods: false
+     # -- Hubble-relay container image.
+@@ -655,7 +675,12 @@
+       useDigest: false
+       pullPolicy: "IfNotPresent"
+     # -- Specifies the resources for the hubble-relay pods
+-    resources: {}
++    resources:
++      requests:
++        cpu: 25m
++        memory: 128Mi
++      limits:
++        memory: 128Mi
+     # -- Number of replicas run for the hubble-relay deployment.
+     replicas: 1
+     # -- Affinity for hubble-replay
+@@ -1157,12 +1182,12 @@
+       - policy_denied
+ encryption:
+   # -- Enable transparent network encryption.
+-  enabled: false
++  enabled: <value:bool>
+   # -- Encryption method. Can be one of ipsec, wireguard or ztunnel.
+-  type: ipsec
++  type: <value:string>
+   # -- Enable encryption for pure node to node traffic.
+   # This option is only effective when encryption.type is set to "wireguard".
+-  nodeEncryption: false
++  nodeEncryption: <value:bool>
+   # -- Configure the Encryption Pod2Pod strict mode.
+   strictMode:
+     # -- Enable Encryption Pod2Pod strict mode. (deprecated: please use encryption.strictMode.egress.enabled)

--- a/tests/patches/snapshots/v1.36.2-rke2r1/rke2-coredns.patch
+++ b/tests/patches/snapshots/v1.36.2-rke2r1/rke2-coredns.patch
@@ -1,0 +1,41 @@
+--- rke2-coredns/values.yaml
++++ rke2-coredns/values.patched.yaml
+@@ -1,10 +1,10 @@
+ resources:
+   limits:
+-    cpu: 100m
+-    memory: 128Mi
++    cpu: "100m" # because of autoscaler
++    memory: "128Mi"
+   requests:
+-    cpu: 100m
+-    memory: 128Mi
++    cpu: "100m"
++    memory: "128Mi"
+ autoscaler:
+   # Enabled the cluster-proportional-autoscaler
+   enabled: true
+@@ -13,7 +13,7 @@
+   # Number of nodes in the cluster per coredns replica
+   nodesPerReplica: 16
+   # Min size of replicaCount
+-  min: 0
++  min: <value:int>
+   # Max size of replicaCount (default of 0 is no max)
+   max: 0
+   # Whether to include unschedulable nodes in the nodes/cores calculations - this requires version 1.8.0+ of the autoscaler
+@@ -56,11 +56,11 @@
+   # resources for autoscaler pod
+   resources:
+     requests:
+-      cpu: "25m"
+-      memory: "16Mi"
++      cpu: "20m"
++      memory: "10Mi"
+     limits:
+       cpu: "100m"
+-      memory: "64Mi"
++      memory: "10Mi"
+   # Options for autoscaler configmap
+   configmap:
+     ## Annotations for the coredns-autoscaler configmap

--- a/tests/patches/test_patches.py
+++ b/tests/patches/test_patches.py
@@ -1,0 +1,76 @@
+import json
+import os
+import tempfile
+from difflib import unified_diff
+from pathlib import Path
+
+import pytest
+
+from helpers import (
+    SNAPSHOTS_DIR,
+    extract_chart_values,
+    merge_patch,
+    patch_top_level_keys,
+    run,
+    sha256_file,
+    patch_keys_diff,
+    version_tag,
+    yq_bin,
+)
+
+
+def test_patches(version, rendered_patches, charts_cache):
+    charts_dir = charts_cache[version]
+    tag = version_tag(version)
+    snapshot_dir = SNAPSHOTS_DIR / tag
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    meta_file = snapshot_dir / "meta.json"
+    meta = json.loads(meta_file.read_text()) if meta_file.is_file() else {}
+    meta.setdefault("rke2_version", version)
+    meta.setdefault("charts", {})
+
+    for chart, patch_file in rendered_patches.items():
+        chart_file = charts_dir / f"{chart}.yaml"
+        snapshot_file = snapshot_dir / f"{chart}.patch"
+
+        assert chart_file.is_file(), f"Missing chart {chart_file} for {version}"
+        assert patch_file.is_file(), f"Missing rendered patch {patch_file}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            values_path, chart_version = extract_chart_values(chart_file, chart, workdir)
+            patched_path = workdir / "patched.yaml"
+            merge_patch(values_path, patch_file, patched_path)
+
+            run([yq_bin(), "e", ".", str(patched_path)])
+
+            for key in patch_top_level_keys(patch_file):
+                run([yq_bin(), "-e", f".{key}", str(patched_path)])
+
+            meta["charts"][chart] = {
+                "chart_version": chart_version,
+                "values_sha256": sha256_file(values_path),
+                "merge_status": "ok",
+            }
+
+            diff_content = patch_keys_diff(values_path, patched_path, patch_file, chart)
+            assert diff_content, f"Patch produced no diff for {chart}@{version}"
+
+            if os.environ.get("UPDATE_SNAPSHOTS") == "1":
+                snapshot_file.write_text(diff_content)
+                continue
+
+            assert snapshot_file.is_file(), (
+                f"Missing snapshot {snapshot_file}; run UPDATE_SNAPSHOTS=1 pytest tests/patches"
+            )
+            expected = snapshot_file.read_text()
+            if diff_content != expected:
+                delta = unified_diff(
+                    expected.splitlines(keepends=True),
+                    diff_content.splitlines(keepends=True),
+                    fromfile=str(snapshot_file),
+                    tofile=f"{chart}@{version}",
+                )
+                pytest.fail("values diff drift:\n" + "".join(delta))
+
+    meta_file.write_text(json.dumps(meta, indent=2) + "\n")

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,278 @@
+@@ -0,0 +1,277 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/67fc8e68a75f738c9200422bf65693fb79a4cd0dc5b23310e5202e978090/pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da", size = 184450, upload-time = "2025-09-25T21:33:00.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/92/861f152ce87c452b11b9d0977952259aa7df792d71c1053365cc7b09cc08/pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917", size = 174319, upload-time = "2025-09-25T21:33:02.086Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cd/f0cfc8c74f8a030017a2b9c771b7f47e5dd702c3e28e5b2071374bda2948/pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9", size = 737631, upload-time = "2025-09-25T21:33:03.25Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/b2/18f2bd28cd2055a79a46c9b0895c0b3d987ce40ee471cecf58a1a0199805/pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5", size = 836795, upload-time = "2025-09-25T21:33:05.014Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b9/793686b2d54b531203c160ef12bec60228a0109c79bae6c1277961026770/pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a", size = 750767, upload-time = "2025-09-25T21:33:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/86/a137b39a611def2ed78b0e66ce2fe13ee701a07c07aebe55c340ed2a050e/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926", size = 727982, upload-time = "2025-09-25T21:33:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/62/71c27c94f457cf4418ef8ccc71735324c549f7e3ea9d34aba50874563561/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7", size = 755677, upload-time = "2025-09-25T21:33:09.876Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/6f5e0d58bd924fb0d06c3a6bad00effbdae2de5adb5cda5648006ffbd8d3/pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0", size = 142592, upload-time = "2025-09-25T21:33:10.983Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0c/25113e0b5e103d7f1490c0e947e303fe4a696c10b501dea7a9f49d4e876c/pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007", size = 158777, upload-time = "2025-09-25T21:33:15.55Z" },
+]
+
+[[package]]
+name = "terraform-openstack-rke2"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = ">=6.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
Extract chart customization into versioned scripts with snapshot tests against RKE2 runtime charts. Fix cloud-init wait helpers by sourcing them from a persistent script so runcmd steps can call wait_for reliably.